### PR TITLE
Fix dockerbuild Foxy issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,9 +43,7 @@ RUN apt-get update  && \
     python3-vcstool
 
 #Update ROS2
-RUN apt update && \
-    rosdep init && \
-    rosdep update --rosdistro=$ROS_DISTRO && \
+RUN rosdep update --rosdistro=$ROS_DISTRO && \
     apt dist-upgrade
 
 RUN mkdir -p $HOME/$ROS2_WORKSPACE


### PR DESCRIPTION
Crash during build_docker.sh during apt-update step. This seems to fix it.
